### PR TITLE
Feedback

### DIFF
--- a/src/modules/Bookmarks.ts
+++ b/src/modules/Bookmarks.ts
@@ -46,7 +46,7 @@ export class BookmarkFactory {
     }
 
     async getAll() {
-        return await Bookmark.all();
+        return await Bookmark.from(this.containerUrl).all();
     }
 
     async get(id: string) {

--- a/src/modules/Bookmarks.ts
+++ b/src/modules/Bookmarks.ts
@@ -55,16 +55,16 @@ export class BookmarkFactory {
 
     async create(payload: ICreateBookmark) {
         const bookmark = new Bookmark(payload);
-        return await await bookmark.save(this.containerUrl);
+        return await bookmark.save(this.containerUrl);
     }
 
     async update(id: string, payload: IBookmark) {
         const bookmark = await Bookmark.find(id);
-        return await await bookmark?.update(payload);
+        return await bookmark?.update(payload);
     }
 
     async remove(id: string) {
         const bookmark = await Bookmark.find(id);
-        return await await bookmark?.delete();
+        return await bookmark?.delete();
     }
 }

--- a/src/modules/Bookmarks.ts
+++ b/src/modules/Bookmarks.ts
@@ -14,17 +14,16 @@ export type IBookmark = ISoukaiDocumentBase & ICreateBookmark
 export const BookmarkSchema = defineSolidModelSchema({
     rdfContexts: {
         'bookm': 'http://www.w3.org/2002/01/bookmark#',
-        'dct': 'http://purl.org/dc/terms/',
     },
     rdfsClasses: ['bookm:Bookmark'],
     timestamps: [TimestampField.CreatedAt],
     fields: {
         title: {
             type: FieldType.String,
-            rdfProperty: 'dct:title',
+            rdfProperty: 'purl:title',
         },
         link: {
-            type: FieldType.String,
+            type: FieldType.Key,
             rdfProperty: 'bookm:recalls',
         },
     },

--- a/src/modules/Profile.ts
+++ b/src/modules/Profile.ts
@@ -1,5 +1,5 @@
 
-import { FieldType, TimestampField } from "soukai";
+import { FieldType } from "soukai";
 import { defineSolidModelSchema } from "soukai-solid";
 import { ISoukaiDocumentBase } from "../shared/contracts";
 
@@ -16,7 +16,6 @@ export type IProfile = ISoukaiDocumentBase & ICreateProfile
 
 export const ProfileSchema = defineSolidModelSchema({
     rdfContexts: {
-        'dct': 'http://purl.org/dc/terms/',
         'ns': 'http://www.w3.org/2006/vcard/ns#',
     },
     rdfsClasses: ['foaf:Person', 'schema:Person'],
@@ -54,16 +53,16 @@ export class ProfileFactory {
 
     async create(payload: ICreateProfile) {
         const profile = new Profile(payload);
-        return await await profile.save(this.containerUrl);
+        return await profile.save(this.containerUrl);
     }
 
     async update(id: string, payload: IProfile) {
         const profile = await Profile.find(id);
-        return await await profile?.update(payload);
+        return await profile?.update(payload);
     }
 
     async remove(id: string) {
         const profile = await Profile.find(id);
-        return await await profile?.delete();
+        return await profile?.delete();
     }
 }

--- a/src/modules/Profile.ts
+++ b/src/modules/Profile.ts
@@ -44,7 +44,7 @@ export class ProfileFactory {
     }
 
     async getAll() {
-        return await Profile.all();
+        return await Profile.from(this.containerUrl).all();
     }
 
     async get(id: string) {


### PR DESCRIPTION
Hey, I've looked at the repo and while I was at it I cleaned up a couple of things I found, feel free to ignore them and close the PR though. The main point of opening this is giving some feedback.

Overall I get the idea of the package and I think it's really nice :). Eventually, if this type of thing becomes more widespread, it'd be nice to arrive at some convention on how these "data modules" packages are done. But so far, I think this is a great start.

I only have one doubt though, and that is why you decided to implement these factories rather than just exporting the models directly. Do you have in mind adding more functionality to those, or it's just a way to encapsulate? I guess it depends on coding style preferences, but I usually avoid adding any unnecessary abstractions. I'm curious to see what you think. 

Other than that, here's a couple of comments on the changes I did in this PR:

- I added a call to `.from()` before using `.all()`. That's important because otherwise, the default collection from the model will be used, and it wouldn't respect the factory's container. The rest of the methods should be fine, but I'm curious how this worked because I think the default collection is something like `solid://bookmarks` which would throw an error in a Solid POD (it works with IndexedDB though, which is what I use in my offline-first apps). However, there is one gotcha here and that is if more than one `.all()` method is called for the same model at the same time, because if you look at [the implementation](https://github.com/NoelDeMartin/soukai-solid/blob/main/src/models/SolidModel.ts#L182..L189) you'll notice it's just setting the collection. One way to work around that could be to sub-class the model in each factory, but that could cause other issues so I guess you can leave it like that for now.

- I changed the declaration for `Bookmark.link` to a `FieldType.Key` because that's what I think it should be looking at the vocab documentation. I looked [at your documentation](https://pdsinterop.org/conventions/bookmark/), and I'm not sure the example is right. I think the link to google should be `<https://www.google.com>`, rather than `"https://www.google.com"`. But maybe I'm wrong, if that's the case then it's fine to declare it as a string.

- There are some [built-in vocabs](https://github.com/noeldemartin/soukai-solid#rdf-definitions) such as `purl:` that you can use. In fact I see you're using `foaf:` without declaring it, so you can do the same with `purl:`. Of course, if you still prefer to call it `dct:` that's fine, there shouldn't be any conflicts.

- I tried to write a test, but I wasn't able to import anything into the test file. I guess you still need to configure some of that.